### PR TITLE
Allow usage of rest-client > 1.99

### DIFF
--- a/storyblok.gemspec
+++ b/storyblok.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'rest-client', '~> 1.8'
+  gem.add_dependency 'rest-client', '>= 1.8.0', '< 3'
 
   gem.add_development_dependency 'bundler', '~> 1.5'
   gem.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
rest-client versions below < 2.1 will not work with Ruby versions >= 2.4 due to some change with the OpenSSL ciphers

see also: rest-client/rest-client#569