### PR TITLE
Use version from cache

### DIFF
--- a/lib/storyblok/client.rb
+++ b/lib/storyblok/client.rb
@@ -171,13 +171,17 @@ module Storyblok
 
     def cached_get(request)
       endpoint = base_url + request.url
-      query = request_query(request.query)
-      query_string = build_nested_query(query)
 
-      if cache.nil? or query[:uncached]
+      if cache.nil?
+        query = request_query(request.query)
+        query_string = build_nested_query(query)
         result = run_request(endpoint, query_string)
       else
         version = cache.get('storyblok:' + configuration[:token] + ':version') || '0'
+
+        query = query = request_query({ cache_version: version }.merge(request.query))
+        query_string = build_nested_query(query)
+
         cache_key = 'storyblok:' + configuration[:token] + ':v:' + version + ':' + request.url + ':' + Base64.encode64(query_string)
 
         result = cache.cache(cache_key) do


### PR DESCRIPTION
I ran into the same problem as described in #8 : Even with with webhooks the wrong `cv` was used, therefore stories were still outdated after cache invalidation.

This fixes that by using the version that was cached in redis for the actual API call.