### PR TITLE
Fix joining array queries by comma

### DIFF
--- a/lib/storyblok/client.rb
+++ b/lib/storyblok/client.rb
@@ -296,9 +296,7 @@ module Storyblok
       def build_nested_query(value, prefix = nil)
         case value
         when Array
-          value.map { |v|
-            build_nested_query(v, "#{prefix}[]")
-          }.join("&")
+          "#{prefix}=#{value.join(',')}"
         when Hash
           value.map { |k, v|
             build_nested_query(v,

--- a/spec/lib/storyblok_client_spec.rb
+++ b/spec/lib/storyblok_client_spec.rb
@@ -855,6 +855,18 @@ describe Storyblok::Client do
           end
         end
       end
+
+      describe "#build_nested_query" do
+        let(:query) { { by_uuids: ["uuid-1", "uuid-2"] } }
+        let(:request) { double("Request", url: "/cdn/stories", query: query) }
+
+        it "joins array query arguments with commas" do
+          allow(subject).to receive(:request_query) { query }
+          expect(subject).to receive(:run_request).with(anything, "by_uuids=uuid-1,uuid-2") { "{}" }
+
+          subject.cached_get(request)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes the issue with array queries. As it's described in the [API docs](https://www.storyblok.com/docs/api/content-delivery/v2#core-resources/stories/retrieve-multiple-stories), the array arguments should be comma-separated. The previous version worked for API v1 but doesn't work for API v2.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

1. Set the API to v2
2. Perform a query with an array argument, e.g. `{ by_uuids: ["uuid-1", "uuid-2"] }`

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed `build_nested_query` to use `join(',')`

before:
```ruby
"by_uuids[]=uuid-1&by_uuids[]=uuid-2"
```

after:
```ruby
"by_uuids=uuid-1,uuid-2"
```

## Other information
