### PR TITLE
fix: add api details for management API to example, remove token requirement.

### DIFF
--- a/examples/management_api.rb
+++ b/examples/management_api.rb
@@ -5,9 +5,10 @@ require 'storyblok'
 logger = Logger.new(STDOUT)
 
 client = Storyblok::Client.new(
-  token: 'A5uTnm0GXLBLhwaGrhHdQwtt',
   oauth_token: 'OAUTH_TOKEN',
-  logger: logger
+  logger: logger,
+  api_url: 'mapi.storyblok.com',
+  api_version: 1
 )
 
 spaces = client.get('spaces')['data']['spaces']


### PR DESCRIPTION
In order to have this client function correctly facing the management API both the api_url and api_version must be specified.

API token is not required for the management API, just an OAuth Token

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- If it's an internal request, please add the Jira link. -->
Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Create an OAuth Token and include it in place of OAUTH_TOKEN, and run the example.  

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

This example previously _did not work_ out of the box because the API was not properly specified for management.  Generally, information on how to use this gem is under documented in this repository and on the main storyblok documentation and most examples will not run out of the box due to this problem.  I suspect there are similar issues on the content API side but this is the only one I've tested and gotten working.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- 
- 
- 

## Other information

The ruby documentation on the Storyblok site generally will not run out of the box due to these issues.
