### PR TITLE
Send JSON payloads properly

### DIFF
--- a/lib/storyblok/client.rb
+++ b/lib/storyblok/client.rb
@@ -134,11 +134,11 @@ module Storyblok
     end
 
     def post(path, payload, additional_headers = {})
-      run_management_request(:post, path, payload, additional_headers)
+      run_management_request(:post, path, payload.to_json, additional_headers.merge({content_type: :json}))
     end
 
     def put(path, payload, additional_headers = {})
-      run_management_request(:put, path, payload, additional_headers)
+      run_management_request(:put, path, payload.to_json, additional_headers.merge({content_type: :json}))
     end
 
     def delete(path, additional_headers = {})


### PR DESCRIPTION
`storyblok_ruby`'s call to RestClient::Resource was causing payloads for `PUT` and `POST` to be sent as `application/x-www-form-urlencoded`, rather than `application/json`. This was causing booleans to be interpreted as strings when updating stories.

This PR updates calls to match the `to_json` examples at https://github.com/rest-client/rest-client

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 
Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

* you'll need a story with a boolean value
* update the story via the API, something like
```ruby
story_client = Storyblok::Client.new(oauth_token: 'TOKEN', api_url: 'mapi.storyblok.com', api_version: 1)
url = "spaces/SPACE/stories/STORY"
story = story_client.get(url)
payload = story['data']['story']
payload['name'] = 'something different'
story_client.put(url, { "story" => payload })
```
* reload the story, and check the Draft JSON. The previously boolean value will now be a string.

## What is the new behavior?

With this PR, booleans stay boolean when stories are updated as above.